### PR TITLE
Node mapping enum to avoid switch statement

### DIFF
--- a/src/main/java/de/cerus/logicbuilder/gui/MainFrame.java
+++ b/src/main/java/de/cerus/logicbuilder/gui/MainFrame.java
@@ -1,10 +1,8 @@
 package de.cerus.logicbuilder.gui;
 
 import com.sun.java.swing.plaf.windows.WindowsLookAndFeel;
-import de.cerus.logicbuilder.gate.impl.*;
-import de.cerus.logicbuilder.input.impl.DefaultInput;
+import de.cerus.logicbuilder.node.NodeMap;
 import de.cerus.logicbuilder.node.NodeRegistry;
-import de.cerus.logicbuilder.output.impl.DefaultOutput;
 
 import javax.swing.*;
 import javax.swing.border.LineBorder;
@@ -39,13 +37,9 @@ public class MainFrame extends JFrame {
 
         JComboBox<String> nodeChooser = new JComboBox<>();
         DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
-        model.addElement("AND Gate");
-        model.addElement("OR Gate");
-        model.addElement("XOR Gate");
-        model.addElement("NOT Gate");
-        model.addElement("Splitter Gate");
-        model.addElement("Input");
-        model.addElement("Output");
+        for (NodeMap node : NodeMap.values()) {
+            model.addElement(node.getItemName());
+        }
         nodeChooser.setModel(model);
         nodeChooser.setBounds(5, 660, 100, 20);
 
@@ -69,30 +63,7 @@ public class MainFrame extends JFrame {
                 return;
             }
 
-            switch (nodeChooser.getSelectedItem().toString()) {
-                case "AND Gate":
-                    NodeRegistry.addGate(new AndGate());
-                    break;
-                case "OR Gate":
-                    NodeRegistry.addGate(new OrGate());
-                    break;
-                case "XOR Gate":
-                    NodeRegistry.addGate(new XorGate());
-                    break;
-                case "NOT Gate":
-                    NodeRegistry.addGate(new InverterGate());
-                    break;
-                case "Splitter Gate":
-                    NodeRegistry.addGate(new SplitterGate());
-                    break;
-                case "Input":
-                    NodeRegistry.addInput(new DefaultInput());
-                    break;
-                case "Output":
-                    NodeRegistry.addOutput(new DefaultOutput());
-                    break;
-            }
-
+            NodeMap.getByName(nodeChooser.getSelectedItem().toString()).run();
             panel.repaint();
         };
     }

--- a/src/main/java/de/cerus/logicbuilder/node/NodeMap.java
+++ b/src/main/java/de/cerus/logicbuilder/node/NodeMap.java
@@ -1,0 +1,63 @@
+package de.cerus.logicbuilder.node;
+
+import de.cerus.logicbuilder.gate.impl.*;
+import de.cerus.logicbuilder.input.impl.DefaultInput;
+import de.cerus.logicbuilder.output.impl.DefaultOutput;
+
+/**
+ * This enum maps nodes by their visible name to their add action.
+ *
+ * @author Paul2708
+ */
+public enum NodeMap {
+
+    AND_GATE("AND Gate", () -> NodeRegistry.addGate(new AndGate())),
+    OR_GATE("OR Gate", () -> NodeRegistry.addGate(new OrGate())),
+    XOR_GATE("XOR Gate", () -> NodeRegistry.addGate(new XorGate())),
+    NOT_GATE("NOT Gate", () -> NodeRegistry.addGate(new InverterGate())),
+    SPLITTER_GATE("Splitter Gate", () -> NodeRegistry.addGate(new SplitterGate())),
+    INPUT("Input", () -> NodeRegistry.addInput(new DefaultInput())),
+    OUTPUT("Output", () -> NodeRegistry.addOutput(new DefaultOutput()));
+
+    private final String itemName;
+    private final Runnable addAction;
+
+    NodeMap(String itemName, Runnable addAction) {
+        this.itemName = itemName;
+        this.addAction = addAction;
+    }
+
+    /**
+     * Get the item name.
+     * The name is used to list the nodes in the combobox.
+     *
+     * @return item name
+     */
+    public String getItemName() {
+        return itemName;
+    }
+
+    /**
+     * Run the add action, so the {@link NodeRegistry} adds the node.
+     */
+    public void run() {
+        addAction.run();
+    }
+
+    /**
+     * Get the node mapping by its item name.
+     *
+     * @param name combo box item name
+     * @return node mapping
+     * @throws IllegalArgumentException if the name doesn't match a mapping (should never happen)
+     */
+    public static NodeMap getByName(String name) {
+        for (NodeMap value : values()) {
+            if (value.getItemName().equals(name)) {
+                return value;
+            }
+        }
+
+        throw new IllegalArgumentException(String.format("%s cannot be matched as Node", name));
+    }
+}


### PR DESCRIPTION
This pr adds an enum that maps a node by its name to its add action.
This should improve the code quality by avoiding a switch statement.
Furthermore, you have only to edit the enum if you want to add new nodes.

Note: There is no `dev` branch as described in the contributing guidelines.